### PR TITLE
rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,8 @@ AllCops:
 
   DisplayCopNames: true
 
-Style/EndOfLine:
+Layout/EndOfLine:
   EnforcedStyle: lf
-
 Layout/LineLength:
   Max: 120
 Metrics/MethodLength:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'rubocop', '>= 1.0', '< 2.0'


### PR DESCRIPTION
- add setup to local linters, to fix LF issues about the 0.48 version